### PR TITLE
Remove Fixed Scopes

### DIFF
--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -4,7 +4,6 @@ require "omniauth-oauth2"
 module OmniAuth
   module Strategies
     class Bitbucket < OmniAuth::Strategies::OAuth2
-
       option :client_options,
              site: "https://bitbucket.org",
              authorize_url: "/site/oauth2/authorize",

--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -4,22 +4,11 @@ require "omniauth-oauth2"
 module OmniAuth
   module Strategies
     class Bitbucket < OmniAuth::Strategies::OAuth2
-      EMAIL = "email".freeze
-      ACCOUNT = "account".freeze
 
       option :client_options,
              site: "https://bitbucket.org",
              authorize_url: "/site/oauth2/authorize",
              token_url: "/site/oauth2/access_token"
-
-      def authorize_params
-        super.tap do |params|
-          scope = params[:scope].to_s.split(/\s+/)
-          scope << EMAIL unless scope.include?(EMAIL)
-          scope << ACCOUNT unless scope.include?(ACCOUNT)
-          params[:scope] = scope.join(" ")
-        end
-      end
 
       def callback_url
         full_host + script_name + callback_path

--- a/test/omniauth/strategies/authorize_params_test.rb
+++ b/test/omniauth/strategies/authorize_params_test.rb
@@ -7,22 +7,15 @@ class AuthorizeParamsTest < Minitest::Test
     OmniAuth::Strategies::Bitbucket.new(app, "consumer_id", "consumer_secret")
   end
 
-  test "sets defaults scopes" do
+  test "dont set a default scope" do
     strategy.stubs(:session).returns({})
-    assert_equal "email account", strategy.authorize_params.scope
-  end
-
-  test "injects required scopes" do
-    strategy = OmniAuth::Strategies::Bitbucket.new(nil, "ID", "SECRET", scope: "team")
-    strategy.stubs(:session).returns({})
-
-    assert_equal "team email account", strategy.authorize_params.scope
+    assert_equal nil, strategy.authorize_params.scope
   end
 
   test "sets unique scopes" do
-    strategy = OmniAuth::Strategies::Bitbucket.new(nil, "ID", "SECRET", scope: "account email")
+    strategy = OmniAuth::Strategies::Bitbucket.new(nil, "ID", "SECRET", scope: "account team")
     strategy.stubs(:session).returns({})
 
-    assert_equal "account email", strategy.authorize_params.scope
+    assert_equal "account team", strategy.authorize_params.scope
   end
 end


### PR DESCRIPTION
Hey Bro, thanks for the Lib :)

But I think Bitbucket doesn't need this fixed scopes anymore

I'm getting the error: 

> Could not authenticate you from Bitbucket because "These requested scopes are beyond the oauth client's own scopes: email".

But, If I manually remove the fixed scope `email`, it works perfeclly

**check at**: https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes